### PR TITLE
Mise à jour de mongo en version 5, changement d'url invalide (?)

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -367,7 +367,6 @@ def python(c):
 
 # https://linuxhint.com/install_mongodb_debian_10/
 def mongodb(c):
-  result = c.run('apt-key list', hide=True)
   c.run('apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4')
   c.run('echo "deb http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/5.0/ main" | tee /etc/apt/sources.list.d/mongodb-org.list')
   c.run('apt-get update')

--- a/fabfile.py
+++ b/fabfile.py
@@ -370,7 +370,7 @@ def mongodb(c):
   result = c.run('apt-key list', hide=True)
   if True or 'Mongo' not in result.stdout:
     c.run('apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4')
-    c.run('echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" | tee /etc/apt/sources.list.d/mongodb-org.list')
+    c.run('echo "deb http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/5.0/ main" | tee /etc/apt/sources.list.d/mongodb-org.list')
     c.run('apt-get update')
   else:
     print('MongoDB packages already setup')

--- a/fabfile.py
+++ b/fabfile.py
@@ -368,12 +368,9 @@ def python(c):
 # https://linuxhint.com/install_mongodb_debian_10/
 def mongodb(c):
   result = c.run('apt-key list', hide=True)
-  if True or 'Mongo' not in result.stdout:
-    c.run('apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4')
-    c.run('echo "deb http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/5.0/ main" | tee /etc/apt/sources.list.d/mongodb-org.list')
-    c.run('apt-get update')
-  else:
-    print('MongoDB packages already setup')
+  c.run('apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4')
+  c.run('echo "deb http://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/5.0/ main" | tee /etc/apt/sources.list.d/mongodb-org.list')
+  c.run('apt-get update')
   c.run('apt-get install --assume-yes mongodb-org')
   c.run('service mongod start')
   c.run('systemctl enable mongod')


### PR DESCRIPTION
## Description

Mise à jour du package Mongo vers la version 5+ en utilisant l'url du package :
[https://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/5.0/](https://repo.mongodb.org/apt/debian/dists/stretch/mongodb-org/5.0/)

Deux points d'attention : 
- l'url utilisée précédemment (et indiquée dans la [doc officielle mongo](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-debian/)) retourne une erreur 404 : [http://repo.mongodb.org/apt/debian%20stretch/mongodb-org/4.0](http://repo.mongodb.org/apt/debian%20stretch/mongodb-org/4.0)
- l'ajout de l'url du répertoire du package se faisait toujours à cause d'une condition qui était toujours à `True` ; le code a été simplifié en conséquence pour toujours ajouter le répertoire du package :
```python
if True or 'Mongo' not in result.stdout:
```