### PR TITLE
Ajoute un cron mensuel pour exécuter le script de génération de stats MongoDB

### DIFF
--- a/roles/bootstrap/tasks/setup_cron.yaml
+++ b/roles/bootstrap/tasks/setup_cron.yaml
@@ -32,10 +32,11 @@
     minute: "0"
     hour: "5"
     job: (cd {{ repository_folder }} && {{ envvar_prefix }} npm run tools:cleaner)
-- name: Create cron job to execute generate_mongo_stats.sh daily
+- name: Create cron job to execute generate_mongo_stats.sh monthly
   become_user: "{{ server_user_name }}"
   ansible.builtin.cron:
-    name: Execute generate_mongo_stats.sh daily {{ item.name }}
+    name: Execute generate_mongo_stats.sh monthly {{ item.name }}
     minute: "0"
     hour: "0"
+    day: "1"
     job: (cd {{ repository_folder }} && {{ envvar_prefix }} npm run tools:generate-mongo-stats)

--- a/roles/bootstrap/tasks/setup_cron.yaml
+++ b/roles/bootstrap/tasks/setup_cron.yaml
@@ -32,3 +32,10 @@
     minute: "0"
     hour: "5"
     job: (cd {{ repository_folder }} && {{ envvar_prefix }} npm run tools:cleaner)
+- name: Create cron job to execute generate_mongo_stats.sh daily
+  become_user: "{{ server_user_name }}"
+  ansible.builtin.cron:
+    name: Execute generate_mongo_stats.sh daily
+    minute: "0"
+    hour: "0"
+    job: (cd {{ repository_folder }}/tools && {{ envvar_prefix }} sh generate_mongo_stats.sh)

--- a/roles/bootstrap/tasks/setup_cron.yaml
+++ b/roles/bootstrap/tasks/setup_cron.yaml
@@ -38,4 +38,4 @@
     name: Execute generate_mongo_stats.sh daily {{ item.name }}
     minute: "0"
     hour: "0"
-    job: (cd {{ repository_folder }}/tools && {{ envvar_prefix }} sh generate_mongo_stats.sh)
+    job: (cd {{ repository_folder }} && {{ envvar_prefix }} npm run tools:generate-mongo-stats)

--- a/roles/bootstrap/tasks/setup_cron.yaml
+++ b/roles/bootstrap/tasks/setup_cron.yaml
@@ -35,7 +35,7 @@
 - name: Create cron job to execute generate_mongo_stats.sh daily
   become_user: "{{ server_user_name }}"
   ansible.builtin.cron:
-    name: Execute generate_mongo_stats.sh daily
+    name: Execute generate_mongo_stats.sh daily {{ item.name }}
     minute: "0"
     hour: "0"
     job: (cd {{ repository_folder }}/tools && {{ envvar_prefix }} sh generate_mongo_stats.sh)


### PR DESCRIPTION
[Tâche associée](https://trello.com/c/eJIZg4Pq/1361-cr%C3%A9er-une-t%C3%A2che-cron-quotidienne-pour-g%C3%A9n%C3%A9rer-les-fichiers-de-statistiques-mongo)

L'exécution est à minuit pile un peu par défaut, peut-être que ce timing est à discuter