### PR TITLE
Add step to build sourcemap in another folder

### DIFF
--- a/inventories/localhost.yaml
+++ b/inventories/localhost.yaml
@@ -22,7 +22,7 @@ virtualmachines:
       applications:
         - name: aides_jeunes
           repository: https://github.com/betagouv/aides-jeunes.git
-          branch: master
+          branch: add_way_to_control_sentry_bundle
           default_site: true
           https: false
           domain: mes-aides.1jeune1solution.beta.gouv.fr

--- a/roles/bootstrap/tasks/setup_webapp.yaml
+++ b/roles/bootstrap/tasks/setup_webapp.yaml
@@ -30,6 +30,15 @@
         - NODE_ENV: production
         - MONGODB_URL: mongodb://127.0.0.1/db_{{ item.name }}
         - MES_AIDES_ROOT_URL: http{{ 's' if item.https }}://{{ item.domain }}
+    - name: Run npm build:front:sourcemap
+      ansible.builtin.command:
+        chdir: "{{ repository_folder }}"
+        cmd: npm run build:front:sourcemap
+      changed_when: true
+      environment:
+        - NODE_ENV: production
+        - MONGODB_URL: mongodb://127.0.0.1/db_{{ item.name }}
+        - MES_AIDES_ROOT_URL: http{{ 's' if item.https }}://{{ item.domain }}
 - name: Pm2 restart {{ item.name }}
   become_user: "{{ server_user_name }}"
   changed_when: true

--- a/roles/bootstrap/tasks/setup_webapp.yaml
+++ b/roles/bootstrap/tasks/setup_webapp.yaml
@@ -35,6 +35,7 @@
         chdir: "{{ repository_folder }}"
         cmd: npm run build:front:sourcemap
       changed_when: true
+      ignore_errors: true
       environment:
         - NODE_ENV: production
         - MONGODB_URL: mongodb://127.0.0.1/db_{{ item.name }}


### PR DESCRIPTION
Pour tester il faut : 
- Supprimer le repo de aides-jeunes sur la machine pour pouvoir cibler la branche `add_way_to_control_sentry_bundle` qui a la commande pour build le sourcemap (npm `run build:front:sourcemap`)
- Ajouter un auth token dans production.js (et production.ts car on veut qu'ils restent les même)
- Ajouté development.js` pour que production.js puisse le loader