### PR TITLE
feat: add cron for certbot renew

### DIFF
--- a/roles/bootstrap/tasks/install_certbot.yaml
+++ b/roles/bootstrap/tasks/install_certbot.yaml
@@ -12,3 +12,9 @@
   register: certbot_register
   changed_when: "'Account registered' not in certbot_register.stdout"
   failed_when: "'Account registered' not in certbot_register.stdout and 'registration of a duplicate account' not in certbot_register.stderr"
+- name: Setup cron job for automatic certificate renewal
+  ansible.builtin.cron:
+    name: Certbot Auto Renewal
+    minute: "0"
+    hour: "2"
+    job: "certbot renew"


### PR DESCRIPTION
ticket: https://trello.com/c/69AlnUYW/1360-ajouter-une-t%C3%A2che-cron-avec-certbot-nginx-pour-r%C3%A9g%C3%A9n%C3%A9rer-les-certificats-de-ndd