### PR TITLE
Augmente le hsts max-age à 10 minutes

### DIFF
--- a/roles/bootstrap/templates/nginx_config.conf.j2
+++ b/roles/bootstrap/templates/nginx_config.conf.j2
@@ -7,7 +7,7 @@
   ssl_certificate_key /etc/letsencrypt/live/{{ service_domain }}/privkey.pem;
   include snippets/ssl_params.conf;
 
-  add_header Strict-Transport-Security "max-age=300; includeSubDomains";
+  add_header Strict-Transport-Security "max-age=600; includeSubDomains";
 
 {%- endmacro %}
 


### PR DESCRIPTION
Incrément à 10 minutes du max-age de hsts.

À noter qu'en valeur cible il faudra l'augmenter à 31536000 secondes (1 an), idéalement en l'incrémentant avec les valeurs recommandées par https://hstspreload.org/