### PR TITLE
Active http2 dans la configuration nginx

### DIFF
--- a/roles/bootstrap/templates/nginx_config.conf.j2
+++ b/roles/bootstrap/templates/nginx_config.conf.j2
@@ -76,7 +76,7 @@ server {
   {{ well_known_section(webroot_path, challenge_proxy) }}
 
   {% if ssl_exists %}
-  listen              443 ssl;
+  listen              443 ssl http2;
   {{ ssl_section() }}
   access_log          /var/log/nginx/{{ service_domain }}.ssl.access.log combined;
   error_log           /var/log/nginx/{{ service_domain }}.ssl.error.log;
@@ -102,7 +102,7 @@ server {
   server_name         {{ service_domain }};
 
   {% if ssl_exists %}
-  listen              443 ssl;
+  listen              443 ssl http2;
   {{ ssl_section() }}
   access_log          /var/log/nginx/{{ service_domain }}.ssl.access.log combined;
   error_log           /var/log/nginx/{{ service_domain }}.ssl.error.log;


### PR DESCRIPTION
## Notes

HTTP2 ne peut être testé que si https est activé ; il faudra tester sur eclipse avant de déployer sur equinoxe.

À noter qu'on est à priori pas impacté par les problèmes très récents de DDOS de nginx lié à HTTP2 ; https://www.nginx.com/blog/http-2-rapid-reset-attack-impacting-f5-nginx-products/

À noter également que HTTP2 demande de désactiver certains ciphers pour ne pas retourner d'erreur : https://httpwg.org/specs/rfc7540.html#BadCipherSuites


PR à merger après la #163 