### PR TITLE
Met à jour les versions de TLS supportées et les ciphers utilisés

### DIFF
--- a/roles/bootstrap/templates/nginx_ssl_params.conf.j2
+++ b/roles/bootstrap/templates/nginx_ssl_params.conf.j2
@@ -1,6 +1,6 @@
-ssl_prefer_server_ciphers on;
-ssl_ciphers         EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA512:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EDH+aRSA:EECDH:!aNULL:!eNULL:!LOW:!RC4:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS;
-ssl_protocols       TLSv1.2 TLSv1.1 TLSv1;
+ssl_prefer_server_ciphers off;
+ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+ssl_protocols       TLSv1.2 TLSv1.3;
 ssl_session_cache   shared:TLS:2m;
 ssl_session_timeout 5m;
 ssl_dhparam         /etc/ssl/private/dhparam.pem;


### PR DESCRIPTION
## Détails

En amont de la PR #161 il est nécessaire de désactiver certains ciphers utilisés aujourd'hui sur la prod.

Ces modifications ont plus de sens dans une PR séparées de manière à séparer et identifier les potentiels problèmes.

À noter qu'une tâche trello est également liée : [Tâche Trello](https://trello.com/c/bWUCGtx9/1172-corriger-les-problèmes-de-certificats-remonté-par-ssllabs)

## Notes

J'ai utilisé [l'outil de génération de configuration de mozilla](https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1k&hsts=false&ocsp=false&guideline=5.7) avec une configuration "intermediate" et en excluant le stapling OCSP.

Je n'ai volontairement pas touché aux paramètres `ssl_session_timeout` et `ssl_session_cache` pour le moment