### PR TITLE
Cron pour envoyer les sondages initiaux par SMS

### DIFF
--- a/roles/bootstrap/tasks/setup_cron.yaml
+++ b/roles/bootstrap/tasks/setup_cron.yaml
@@ -29,7 +29,7 @@
     job: >-
       (cd {{ repository_folder }} &&
       {{ envvar_prefix }} /usr/bin/node
-      ./dist-server/backend/lib/sms-sending-tool.js send initial-survey
+      ./dist-server/tools/sms-sending-tool.js send initial-survey
       --multiple 1000 >> /var/log/{{ server_user_name }}/{{ item.name }}_sms.log 2>&1)
 - name: Add a cron job to anonymize Simulation and Followup data collections
   become_user: "{{ server_user_name }}"

--- a/roles/bootstrap/tasks/setup_cron.yaml
+++ b/roles/bootstrap/tasks/setup_cron.yaml
@@ -20,6 +20,17 @@
       {{ envvar_prefix }} /usr/bin/node
       ./dist-server/tools/email-sending-tool.js send initial-survey
       --multiple 1000 >> /var/log/{{ server_user_name }}/{{ item.name }}_emails.log 2>&1)
+- name: Add a cron job to send initial survey by sms
+  become_user: "{{ server_user_name }}"
+  ansible.builtin.cron:
+    name: send initial survey sms for {{ item.name }}
+    minute: "8"
+    hour: "4"
+    job: >-
+      (cd {{ repository_folder }} &&
+      {{ envvar_prefix }} /usr/bin/node
+      ./dist-server/backend/lib/sms-sending-tool.js send initial-survey
+      --multiple 1000 >> /var/log/{{ server_user_name }}/{{ item.name }}_sms.log 2>&1)
 - name: Add a cron job to anonymize Simulation and Followup data collections
   become_user: "{{ server_user_name }}"
   ansible.builtin.cron:

--- a/roles/bootstrap/tasks/setup_cron.yaml
+++ b/roles/bootstrap/tasks/setup_cron.yaml
@@ -25,7 +25,7 @@
   ansible.builtin.cron:
     name: send initial survey sms for {{ item.name }}
     minute: "8"
-    hour: "4"
+    hour: "17"
     job: >-
       (cd {{ repository_folder }} &&
       {{ envvar_prefix }} /usr/bin/node

--- a/roles/bootstrap/tasks/setup_cron.yaml
+++ b/roles/bootstrap/tasks/setup_cron.yaml
@@ -30,7 +30,7 @@
       (cd {{ repository_folder }} &&
       {{ envvar_prefix }} /usr/bin/node
       ./dist-server/tools/sms-sending-tool.js send initial-survey
-      --multiple 1000 >> /var/log/{{ server_user_name }}/{{ item.name }}_sms.log 2>&1)
+      --multiple 100 >> /var/log/{{ server_user_name }}/{{ item.name }}_sms.log 2>&1)
 - name: Add a cron job to anonymize Simulation and Followup data collections
   become_user: "{{ server_user_name }}"
   ansible.builtin.cron:


### PR DESCRIPTION
Ajoute le cron pour l'envoi du sondage initial par sms et renomage de l'outil d'envoi d'email.