### PR TITLE
Ajoute un restart on-failure pour le service openfisca

### DIFF
--- a/roles/bootstrap/templates/openfisca.service.j2
+++ b/roles/bootstrap/templates/openfisca.service.j2
@@ -7,6 +7,7 @@ Group={{ server_user_group }}
 Environment="OPENFISCA_WORKERS={{ item.openfisca_worker_number | default(3) }}" "OPENFISCA_PORT={{ item.openfisca_server_port }}"
 WorkingDirectory={{ repository_folder }}/
 ExecStart={{ venv_dir }}/bin/gunicorn openfisca.api --config openfisca/config.py
+Restart=on-failure
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
Le service openfisca était down sur la production et n'a pas été relancé. 

https://pad.incubateur.net/AnH7KDaBTuiTpjKkhj8ocA?both 