### PR TITLE
Utilise la branche dev pour le déploiement du répo aides-jeunes-ops sur eclipse

### DIFF
--- a/inventories/eclipse.yaml
+++ b/inventories/eclipse.yaml
@@ -41,5 +41,5 @@ virtualmachines:
           openfisca_worker_number: 2
       ops:
         repository: https://github.com/betagouv/aides-jeunes-ops.git
-        branch: main
+        branch: dev
         update_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILf+3BWu3FJDmuouJK1SuAaQrPLmJrBR1xMf5fGCJtGz eclipse@eclipse


### PR DESCRIPTION
Si on pousse une modification sur la branche `dev` de l'ops, le déploiement continu actuel utilise la branche `main` pour mettre à jour le répo de l'ops (situé dans `/opt/mes-aides`) sur Eclipse

À mon sens, Eclipse est présent pour faire des tests sur l'ops et on devrait pouvoir déployer ce qui est présent sur la branche `dev` pour éviter de devoir déployer sur `main` qui est la branche utilisée par l'ops en production.