### PR TITLE
Mise à jour OPS - tentative de correction du déploiement sur eclipse

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v4
       - name: Cache Python dependencies
         uses: actions/cache@v4
         id: python-dependencies
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v4
       - name: Cache Python dependencies
         uses: actions/cache@v4
         id: python-dependencies

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
       - name: Cache Python dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: python-dependencies
         with:
           path: ${{ env.pythonLocation }}
@@ -36,11 +36,11 @@ jobs:
     needs: [install_python_requirements]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
       - name: Cache Python dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: python-dependencies
         with:
           path: ${{ env.pythonLocation }}

--- a/synchronize.yaml
+++ b/synchronize.yaml
@@ -2,7 +2,13 @@
 - name: Synchronize Ops repository with server
   become: true
   hosts: all
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
   tasks:
+    - name: Ensure python3-apt is installed (required for apt module)
+      ansible.builtin.apt:
+        name: python3-apt
+        state: present
     - name: Install continuous deployment tools
       ansible.builtin.apt:
         name: [git, python3-pip]
@@ -18,7 +24,8 @@
         update: true
         clone: true
         single_branch: true
-        version: "{{ ops.branch | default('main') }}"
+        force: true
+        version: "main"
       when: ops.repository is defined
     - name: Set deployment variables
       ansible.builtin.set_fact:

--- a/synchronize.yaml
+++ b/synchronize.yaml
@@ -2,13 +2,7 @@
 - name: Synchronize Ops repository with server
   become: true
   hosts: all
-  vars:
-    ansible_python_interpreter: /usr/bin/python3
   tasks:
-    - name: Ensure python3-apt is installed (required for apt module)
-      ansible.builtin.apt:
-        name: python3-apt
-        state: present
     - name: Install continuous deployment tools
       ansible.builtin.apt:
         name: [git, python3-pip]
@@ -24,8 +18,7 @@
         update: true
         clone: true
         single_branch: true
-        force: true
-        version: "main"
+        version: "{{ ops.branch }}"
       when: ops.repository is defined
     - name: Set deployment variables
       ansible.builtin.set_fact:

--- a/synchronize.yaml
+++ b/synchronize.yaml
@@ -10,6 +10,7 @@
     - name: Install ansible on host
       ansible.builtin.pip:
         name: ansible
+        extra_args: "--break-system-packages"
     - name: Clone application repository
       ansible.builtin.git:
         repo: "{{ ops.repository }}"


### PR DESCRIPTION
- `extra_args: "--break-system-packages"` => permettrait de corriger l'installation Ansible avec la version de python sur la préproduction (v3.9.2 en production, v3.12.2 rétrogradée en v3.9.1 durant mon process de debug, fonctionnel comme ça)
- Mise à jour des versions des github action `actions/checkout`, `actions/cache`