### PR TITLE
Setup la roation des journaux systemd

### DIFF
--- a/roles/bootstrap/handlers/main.yaml
+++ b/roles/bootstrap/handlers/main.yaml
@@ -8,3 +8,7 @@
   ansible.builtin.service:
     name: sshd
     state: restarted
+- name: restart systemd-journald
+  ansible.builtin.service:
+    name: systemd-journald
+    state: restarted

--- a/roles/bootstrap/handlers/main.yaml
+++ b/roles/bootstrap/handlers/main.yaml
@@ -8,7 +8,7 @@
   ansible.builtin.service:
     name: sshd
     state: restarted
-- name: restart systemd-journald
+- name: Restart systemd-journald
   ansible.builtin.service:
     name: systemd-journald
     state: restarted

--- a/roles/bootstrap/tasks/main.yaml
+++ b/roles/bootstrap/tasks/main.yaml
@@ -27,6 +27,10 @@
 - name: Install and configure certbot
   ansible.builtin.include_tasks: install_certbot.yaml
 
+## Setup systemd
+- name: Setup systemd journal rotation
+  ansible.builtin.include_tasks: setup_systemd_journal.yaml
+
 ## Setup Monitoring service
 - name: Configure monitoring service
   ansible.builtin.include_tasks: setup_monitor.yaml

--- a/roles/bootstrap/tasks/setup_systemd_journal.yaml
+++ b/roles/bootstrap/tasks/setup_systemd_journal.yaml
@@ -6,10 +6,10 @@
       [Journal]
       SystemMaxUse=2G
       SystemMaxFileSize=100M
-      MaxRetentionSec=90d
+      MaxRetentionSec=30d
       Compress=yes
   notify: Restart systemd-journald
 
 - name: Force immediate cleanup of old journals
-  ansible.builtin.command: journalctl --vacuum-time=90d
+  ansible.builtin.command: journalctl --vacuum-time=30d
   changed_when: true

--- a/roles/bootstrap/tasks/setup_systemd_journal.yaml
+++ b/roles/bootstrap/tasks/setup_systemd_journal.yaml
@@ -8,7 +8,7 @@
       SystemMaxFileSize=100M
       MaxRetentionSec=90d
       Compress=yes
-  notify: restart systemd-journald
+  notify: Restart systemd-journald
 
 - name: Force immediate cleanup of old journals
   ansible.builtin.command: journalctl --vacuum-time=90d

--- a/roles/bootstrap/tasks/setup_systemd_journal.yaml
+++ b/roles/bootstrap/tasks/setup_systemd_journal.yaml
@@ -1,0 +1,15 @@
+---
+- name: Setup systemd journal rotation
+  ansible.builtin.blockinfile:
+    path: /etc/systemd/journald.conf
+    block: |
+      [Journal]
+      SystemMaxUse=2G
+      SystemMaxFileSize=100M
+      MaxRetentionSec=90d
+      Compress=yes
+  notify: restart systemd-journald
+
+- name: Force immediate cleanup of old journals
+  ansible.builtin.command: journalctl --vacuum-time=90d
+  changed_when: true


### PR DESCRIPTION
## Procédure / investigation effectuée sur la pré-production

Espace actuel sur `/var/log` : 
```
# du -sh /var/log
3.1G	/var/log

# du -h * | sort -hr | head -n 10
2.4G	journal/fd0521a42fe0428b995fe75d36995a4b
2.4G	journal
88M	mongodb
22M	btmp
21M	btmp.1
8.5M	auth.log.1
5.1M	main
4.0M	nginx
3.3M	auth.log
```

On constate que c'est les journaux qui prennent le plus de place (plus de 2.4G).
J'ai donc lancé la commande pour supprimer tous les journaux de plus de 30 jours:

```
journalctl --vacuum-time=30d
```
Résultat : 
```
Vacuuming done, freed 2.1G of archived journals from /var/log/journal/fd0521a42fe0428b995fe75d36995a4b.
Vacuuming done, freed 0B of archived journals from /var/log/journal.
```

Vérification du poids post traitement :
```
# journalctl --disk-usage
Archived and active journals take up 236.2M in the file system.

# du -h * | sort -hr | head -n 10
42M	system@693f4b9529004d63aa21d297a40e91cc-0000000000576fc5-0006251ba9b32815.journal
42M	system@693f4b9529004d63aa21d297a40e91cc-0000000000558d25-000623fcf1b85fe8.journal
41M	system@693f4b9529004d63aa21d297a40e91cc-00000000005694a8-00062494ee9d16e1.journal
41M	system@693f4b9529004d63aa21d297a40e91cc-000000000054bf70-00062379fabc3bc1.journal
17M	system.journal
12M	user-1000@8be920b2e7294d8a88dfbc51f201d8ae-000000000055a9b0-0006240bda797840.journal
8.0M	user-1001.journal
8.0M	user-1000.journal
5.0M	user-1000@8be920b2e7294d8a88dfbc51f201d8ae-0000000000569b4a-00062497b1ff66a5.journal
4.8M	user-1000@8be920b2e7294d8a88dfbc51f201d8ae-000000000054c3a3-0006237b2f8d1d60.journal
```

Il n'y a pas de délai préconisé par l'Etat en ce qui concerne le délai de conservation des journaux, aussi il est souvent recommandé de les conserver sur une plage de 3 à 6 mois. Pour la production, si on choisi 3 mois on devra utiliser cette commande pour le nettoyage manuel :

```
journalctl --vacuum-time=3month
```

## Ajouts proposés par cette PR

Configuration ansible pour la mise en place de la conservation des journaux à 90 jours avec un clean effectif à chaque déploiement.