### PR TITLE
Ajout conditions certificats SSL / Let's Encrypt & définition options par défaut pour certbot

### DIFF
--- a/inventories/eclipse.yaml
+++ b/inventories/eclipse.yaml
@@ -43,3 +43,8 @@ virtualmachines:
         repository: https://github.com/betagouv/aides-jeunes-ops.git
         branch: dev
         update_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILf+3BWu3FJDmuouJK1SuAaQrPLmJrBR1xMf5fGCJtGz eclipse@eclipse
+      ignored_ssl_domains:
+        - preprod.mes-aides.incubateur.net
+        - openfisca.preprod.mes-aides.incubateur.net
+        - openfisca.mes-aides.1jeune1solution.beta.gouv.fr
+        - mes-aides.1jeune1solution.beta.gouv.fr

--- a/roles/bootstrap/tasks/nginx_site.yaml
+++ b/roles/bootstrap/tasks/nginx_site.yaml
@@ -5,8 +5,19 @@
       ansible.builtin.stat:
         path: /etc/letsencrypt/live/{{ service_domain }}/fullchain.pem
       register: certificate
+    - name: Set default certbot options
+      ansible.builtin.set_fact:
+        certbot_www_option: ""
+    - name: Debug - Print service domain and ignored domains
+      ansible.builtin.debug:
+        msg: |
+          Current service domain: {{ service_domain }}
+          Ignored SSL domains: {{ ignored_ssl_domains | default([]) }}
     - name: Generate certificate if missing
-      when: (not certificate.stat.exists) and (https | default(false))
+      when: >
+        (not certificate.stat.exists) and
+        (https | default(false)) and
+        (service_domain not in (ignored_ssl_domains | default([])))
       block:
         - name: Set SSL state
           ansible.builtin.set_fact:
@@ -24,6 +35,8 @@
         - name: Issue or renew an SSL certificate with Let's Encrypt
           ansible.builtin.command: >
             certbot --nginx
+            --non-interactive
+            --agree-tos
             -d {{ service_domain }}
             {{ certbot_www_option }}
           register: lets_encrypt_success


### PR DESCRIPTION
- `certbot_www_option` pouvait être undefined, ici on l'initialise pour éviter l'erreur
- Les certificats SSL avec Let's Encrypt lié à Eclipse et Equinoxe ne sont générés que sur leurs inventories respectifs
- Ajout d'une option pour accepter directement en mode non interactif la commande du renouvellement de certificat SSL