### PR TITLE
Ajout de noindex en preprod

### DIFF
--- a/roles/bootstrap/templates/nginx_config.conf.j2
+++ b/roles/bootstrap/templates/nginx_config.conf.j2
@@ -11,6 +11,11 @@
 
 {%- endmacro %}
 
+{% if 'preprod' in service_domain %}
+    # Add noindex for preprod environments
+    add_header X-Robots-Tag "noindex, nofollow" always;
+{% endif %}
+
 {% macro proxy_section(pass) -%}
     # Enable Keepalive Connections
     # https://www.nginx.com/blog/tuning-nginx/#keepalive


### PR DESCRIPTION
```
/etc/nginx/sites-enabled# cat preprod.mes-aides.incubateur.net.conf 
# MANAGED BY MES AIDES OPS
# Modifications should be made in that template
    # Add noindex for preprod environments
    add_header X-Robots-Tag "noindex, nofollow" always;
```
Difficile à tester avec docker mais réalisable en poussant en preprod.
Voici le fichier en résultat ci-dessus.
cf : https://github.com/betagouv/aides-jeunes/issues/4875